### PR TITLE
fixed data directive spacing

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -103,7 +103,7 @@ function ViewModel() {
 
         var data = '';
         if (self.editorContent() !== '') {
-            data = '--data \'' + self.editorContent() + '\'';
+            data = ' --data \'' + self.editorContent() + '\'';
         }
 
         var auth = '';


### PR DESCRIPTION
Sometimes the data directive will not be separated from the previous directive, causing issues when attempting to run the curl.